### PR TITLE
Include deviation in spending anomaly insights

### DIFF
--- a/bot/handlers/insights.py
+++ b/bot/handlers/insights.py
@@ -142,11 +142,12 @@ async def _show_spending_anomalies(query, user_id, analysis_service):
 
     for i, anomaly in enumerate(anomalies[:5], 1):  # Show top 5
         severity_emoji = "🔴" if anomaly['severity'] == 'high' else "🟡"
+        deviation = anomaly.get('deviation', 0)
         anomaly_text += (
             f"{severity_emoji} <b>Anomaly #{i}</b>\n"
             f"📅 Date: {anomaly['date']}\n"
             f"💰 Amount: {anomaly['amount']:,.0f} IDR\n"
-            f"📊 Deviation: +{anomaly['deviation']:,.0f} IDR above average\n"
+            f"📊 Deviation: {deviation:+,.0f} IDR from average\n"
             f"⚠️ Severity: {anomaly['severity'].title()}\n\n"
         )
 


### PR DESCRIPTION
## Summary
- compute average daily spending and attach deviation to anomaly results
- display deviation in spending anomaly insights with proper sign formatting

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6896280c26d0833390c2fde17250e7e0