### PR TITLE
ci: build and push Docker image to GitHub Packages

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,29 @@
+name: Build and Push Docker image
+
+on:
+  push:
+    branches:
+      - main
+      - master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ghcr.io/${{ github.repository_owner }}/mandiri-statement-bot:latest
+


### PR DESCRIPTION
## Summary
- add workflow to build and push Docker image to GHCR on pushes to main or master

## Testing
- `pylint $(find . -type f -name "*.py" -not -path "./alembic/*")`

------
https://chatgpt.com/codex/tasks/task_e_68962c474cc083339f62172bee09e69a